### PR TITLE
Update JDK's to latest that can be pulled from sun/oracle.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,13 +6,13 @@ emailBreaks {
             git 'https://github.com/TiVo/docker-alpine-java.git'
         }
         stage('Build Docker Images') {
-            dir('8/102b14/server-jre/standard/') {
+            dir('8/162b12/server-jre/standard/') {
                 docker.withRegistry('https://docker.tivo.com', 'docker-registry') {
                     def image = docker.build("alpine-java:8_server-jre", "--pull .")
                     image.push()
                 }
             }
-            dir('8/102b14/jdk/standard/') {
+            dir('8/162b12/jdk/standard/') {
                 docker.withRegistry('https://docker.tivo.com', 'docker-registry') {
                     def image = docker.build("alpine-java:8_jdk", "--pull .")
                     image.push()


### PR DESCRIPTION
My local docker build of these succeeded. Per the diff, we'll jump from 8u102 to 8u162.

Do we need to backup the current alpine-java:8_server-jre and alpine-java:8_jdk tagged images first? This build does not seem to date tag/latest tag images. (looks at artifactory) Yes, we should(?) probably back up/retag the original images. ... 

OK, they are backed up.